### PR TITLE
feat(guestStorage): generate UUID for each new mood entry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "next": "15.3.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-icons": "^5.5.0"
+        "react-icons": "^5.5.0",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -5832,6 +5833,19 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "next": "15.3.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-icons": "^5.5.0"
+    "react-icons": "^5.5.0",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/services/guestStorage.ts
+++ b/src/services/guestStorage.ts
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from "uuid";
+
 export type Mood = {
   id: string;
   mood_score: number;
@@ -8,9 +10,13 @@ export type Mood = {
 };
 
 export function saveMoodLocally(newMood: Mood) {
+  const moodWithId: Mood = {
+    ...newMood,
+    id: newMood.id || uuidv4(),
+  };
   const existing = localStorage.getItem("guest_moods");
   const moods: Mood[] = existing ? JSON.parse(existing) : [];
-  moods.push(newMood);
+  moods.push(moodWithId);
   localStorage.setItem("guest_moods", JSON.stringify(moods));
 }
 


### PR DESCRIPTION
- יצירת מזהה ייחודי (UUID) לכל מצב רוח חדש שנשמר במצב אנונימי.
המזהה נשמר בשדה `id`, ונוצר רק אם לא קיים מראש — כדי לאפשר ייבוא ממקורות אחרים.
שינוי זה יאפשר סינון כפילויות בצד שרת בהמשך.