### PR TITLE
Feature/mood entry local and server save

### DIFF
--- a/src/components/MoodLogForm.tsx
+++ b/src/components/MoodLogForm.tsx
@@ -6,6 +6,7 @@ import Step2SelectEmotions from "./moodLog/Step2SelectEmotions";
 import Step3MoodNote from "./moodLog/Step3MoodNote";
 import Step4Summary from "./moodLog/Step4Summary";
 import { useRouter } from "next/navigation";
+import { useAuthCheck } from "@/hooks/useAuthCheck";
 
 const positive_emotions = [
   "אמון",
@@ -85,15 +86,33 @@ export default function MoodLogForm() {
   const [moodScore, setMoodScore] = useState(5);
   const [selectedEmotions, setSelectedEmotions] = useState<string[]>([]);
   const [note, setNote] = useState("");
+  const { user } = useAuthCheck();
+
+  console.log(user);
 
   const router = useRouter();
 
   const saveMood = () => {
-    console.log("📦 נשמר רישום:", {
+    if (selectedEmotions.length === 0) {
+      alert("יש לבחור לפחות רגש אחד כדי להמשיך");
+      return;
+    }
+
+    const moodEntry = {
+      id: crypto.randomUUID(),
+      createdAt: new Date().toISOString(),
       moodScore,
       selectedEmotions,
       note,
-    });
+    };
+
+    if (user === "guest") {
+      // שמירה מקומית
+      console.log("שמירה מקומית:", moodEntry);
+    } else {
+      // שליחה לשרת
+      console.log("שליחה לשרת:", moodEntry);
+    }
 
     router.push("/app");
   };

--- a/src/components/MoodLogForm.tsx
+++ b/src/components/MoodLogForm.tsx
@@ -7,6 +7,7 @@ import Step3MoodNote from "./moodLog/Step3MoodNote";
 import Step4Summary from "./moodLog/Step4Summary";
 import { useRouter } from "next/navigation";
 import { useAuthCheck } from "@/hooks/useAuthCheck";
+import { saveMoodEntry } from "@/services/localMoodService";
 
 const positive_emotions = [
   "אמון",
@@ -108,7 +109,8 @@ export default function MoodLogForm() {
 
     if (user === "guest") {
       // שמירה מקומית
-      console.log("שמירה מקומית:", moodEntry);
+      saveMoodEntry(moodEntry); // שמירה בפועל ב־localStorage
+      console.log("✔️ הרישום נשמר לוקאלית בהצלחה");
     } else {
       // שליחה לשרת
       console.log("שליחה לשרת:", moodEntry);

--- a/src/services/localMoodService.ts
+++ b/src/services/localMoodService.ts
@@ -1,1 +1,17 @@
-const saveMoodEntry = (params: type) => {};
+import { MoodEntry } from "@/types/MoodEntry";
+
+const STORAGE_KEY = "guest_mood_entries";
+
+export function saveMoodEntry(entry: MoodEntry) {
+  // שלב 1: שליפה מה־localStorage
+  const existingEntriesJSON = localStorage.getItem(STORAGE_KEY);
+  const existingEntries: MoodEntry[] = existingEntriesJSON
+    ? JSON.parse(existingEntriesJSON)
+    : [];
+
+  // שלב 2: הוספת הרשומה החדשה למערך
+  existingEntries.push(entry);
+
+  // שלב 3: שמירה חזרה ל־localStorage
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(existingEntries));
+}

--- a/src/services/localMoodService.ts
+++ b/src/services/localMoodService.ts
@@ -1,0 +1,1 @@
+const saveMoodEntry = (params: type) => {};

--- a/src/types/MoodEntry.ts
+++ b/src/types/MoodEntry.ts
@@ -1,0 +1,7 @@
+export interface MoodEntry {
+  id: string; // UUID
+  createdAt: string; // תאריך ISO
+  moodScore: number; // מ-1 עד 10
+  selectedEmotions: string[]; // רגשות שנבחרו
+  note?: string; // הערה חופשית (לא חובה)
+}


### PR DESCRIPTION
הוספת תמיכה בשמירת רשומות מצב רוח בצד הלקוח:

משתמש אורח – שמירה ל־localStorage.

משתמש מחובר – הכנה לשליחה לשרת (עדיין לא פעיל ללא Google Login בפרונט).

✅ מה בוצע
 טופס רישום מצב רוח

 שירות שמירה ל־localStorage

 טיפוס נתונים MoodEntry

 ולידציה בסיסית

 hook לבדיקה אם המשתמש Guest או Logged-In

 תיעוד ב־docs/feature_mood_entry_save.md

 עודכן development_progress_summary.md