### PR TITLE
Connect MoodLogForm to server for authenticated users

### DIFF
--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -19,7 +19,7 @@ export default function AppPage() {
   };
 
   const handleLogout = () => {
-    localStorage.removeItem("access_token");
+    localStorage.removeItem("scb_token");
     localStorage.removeItem("guest_mode");
     router.push("/");
   };

--- a/src/components/MoodLogForm.tsx
+++ b/src/components/MoodLogForm.tsx
@@ -7,7 +7,10 @@ import Step3MoodNote from "./moodLog/Step3MoodNote";
 import Step4Summary from "./moodLog/Step4Summary";
 import { useRouter } from "next/navigation";
 import { useAuthCheck } from "@/hooks/useAuthCheck";
-import { saveMoodEntry } from "@/services/localMoodService";
+import {
+  saveMoodEntry,
+  sendMoodEntryToServer,
+} from "@/services/localMoodService";
 
 const positive_emotions = [
   "אמון",
@@ -93,7 +96,7 @@ export default function MoodLogForm() {
 
   const router = useRouter();
 
-  const saveMood = () => {
+  const saveMood = async () => {
     if (selectedEmotions.length === 0) {
       alert("יש לבחור לפחות רגש אחד כדי להמשיך");
       return;
@@ -110,10 +113,19 @@ export default function MoodLogForm() {
     if (user === "guest") {
       // שמירה מקומית
       saveMoodEntry(moodEntry); // שמירה בפועל ב־localStorage
-      console.log("✔️ הרישום נשמר לוקאלית בהצלחה");
     } else {
       // שליחה לשרת
-      console.log("שליחה לשרת:", moodEntry);
+      try {
+        await sendMoodEntryToServer({
+          mood_score: moodScore,
+          emotions: selectedEmotions,
+          note,
+        });
+        console.log("✔️ נשלח לשרת בהצלחה");
+      } catch (error) {
+        console.error("שליחה לשרת נכשלה:", error);
+        alert("אירעה שגיאה בשליחה לשרת");
+      }
     }
 
     router.push("/app");

--- a/src/services/localMoodService.ts
+++ b/src/services/localMoodService.ts
@@ -15,3 +15,31 @@ export function saveMoodEntry(entry: MoodEntry) {
   // שלב 3: שמירה חזרה ל־localStorage
   localStorage.setItem(STORAGE_KEY, JSON.stringify(existingEntries));
 }
+
+export async function sendMoodEntryToServer({
+  mood_score,
+  emotions,
+  note,
+}: {
+  mood_score: number;
+  emotions: string[];
+  note?: string;
+}): Promise<Response> {
+  const client_id = crypto.randomUUID();
+
+  const token = localStorage.getItem("scb_token");
+
+  return await fetch("http://localhost:8000/mood/add", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      client_id,
+      mood_score: mood_score,
+      emotions: emotions,
+      note,
+    }),
+  });
+}


### PR DESCRIPTION
## 🧩 תיאור הפיצ'ר

שמירת רישום מצב רוח (Mood Entry) לשרת, רק עבור משתמשים שמחוברים עם גוגל.  
כולל שליחה עם טוקן, client_id ייחודי, והגנה על הנתיב בצד שרת.

---

## ✅ מה בוצע

- יצירת פונקציית `sendMoodEntryToServer`
- שליחה בפועל מהטופס הראשי `MoodLogForm`
- ולידציה בסיסית למניעת רישום ריק